### PR TITLE
zoom level on on mobile

### DIFF
--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -3,6 +3,8 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    
     <title>{{ title }} | A Moderately Short PHP Tutorial</title>
     <link rel="stylesheet" href="css/styles.css?v=1.0">
 


### PR DESCRIPTION
This is needed for the page to be as wide as the viewport instead of trying to scale the page down to fit the viewport.


BEFORE:
<img width="456" alt="Screenshot 2020-03-02 at 15 15 46" src="https://user-images.githubusercontent.com/33517841/75689214-b6ce9e00-5c98-11ea-86bf-b8fe8c2b0bf7.png">

AFTER:
<img width="401" alt="Screenshot 2020-03-02 at 15 16 58" src="https://user-images.githubusercontent.com/33517841/75689331-eaa9c380-5c98-11ea-9048-a84e3d60a4a1.png">
